### PR TITLE
Add vitamin color homepage template

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>My Page</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="container">
+      <h1>My Page</h1>
+      <nav class="site-nav">
+        <ul>
+          <li><a href="#about">About</a></li>
+          <li><a href="#gallery">Gallery</a></li>
+          <li><a href="#contact">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section id="about" class="container">
+      <h2>About</h2>
+      <p>ここに既存のWordPressのテキストを貼り付けてください。</p>
+    </section>
+
+    <section id="gallery" class="container">
+      <h2>Gallery</h2>
+      <p>ここに画像ギャラリーを配置してください。</p>
+      <img src="images/sample1.jpg" alt="サンプル画像1" class="responsive" />
+    </section>
+
+    <section id="contact" class="container">
+      <h2>Contact</h2>
+      <p>ここに連絡先情報を貼り付けてください。</p>
+      <a href="mailto:example@example.com" class="btn">メールを送る</a>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <p>&copy; 2024 My Page</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,72 @@
+:root {
+  --main-color: #ffde59;
+  --accent-color: #ffbd59;
+}
+
+body {
+  font-family: 'Hiragino Kaku Gothic Pro', 'Meiryo', sans-serif;
+  margin: 0;
+  background: #ffffff;
+  color: #333333;
+  line-height: 1.8;
+}
+
+.container {
+  width: min(90%, 960px);
+  margin: 0 auto;
+}
+
+.site-header {
+  background: var(--main-color);
+  padding: 1rem 0;
+  text-align: center;
+}
+
+.site-nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.site-nav a {
+  color: #333333;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.site-nav a:hover {
+  color: var(--accent-color);
+}
+
+section {
+  padding: 2rem 0;
+}
+
+h1, h2 {
+  margin-top: 0;
+}
+
+.responsive {
+  max-width: 100%;
+  height: auto;
+  border-radius: 8px;
+}
+
+.btn {
+  display: inline-block;
+  background: var(--accent-color);
+  color: #333333;
+  padding: 0.5rem 1rem;
+  text-decoration: none;
+  border-radius: 4px;
+}
+
+.site-footer {
+  background: var(--main-color);
+  padding: 1rem 0;
+  text-align: center;
+  margin-top: 2rem;
+}


### PR DESCRIPTION
## Summary
- Set up simple homepage skeleton using main color `#ffde59` and accent `#ffbd59`
- Apply Gothic-inspired font stack and responsive layout with balanced whitespace
- Provide placeholder sections for About, Gallery, and Contact

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895ec0ede30832d90d704676d1f86f3